### PR TITLE
Screen reader fix

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -408,11 +408,12 @@
 
     renderTitle = function(instance, c, year, month, refYear, randId)
     {
+        var currentDate = instance.toString('L');        
         var i, j, arr,
             opts = instance._o,
             isMinYear = year === opts.minYear,
             isMaxYear = year === opts.maxYear,
-            html = '<div id="' + randId + '" class="pika-title" role="heading" aria-live="polite">',
+            html = '<div id="' + randId + '" aria-label="' + currentDate + '" class="pika-title" role="heading" aria-live="polite">',
             monthHtml,
             yearHtml,
             prev = true,


### PR DESCRIPTION
While screen reader is activated, when trying to select a date the screenreader does not say the date out load instead says 'month month year year' i.e 'April April 2022 2022'.
This fix will resolve that issue and also format it to be read correctly based on the system's date format.